### PR TITLE
Making nettle optional (again)

### DIFF
--- a/configure
+++ b/configure
@@ -783,6 +783,7 @@ with_gnu_ld
 with_sysroot
 enable_libtool_lock
 enable_shadow
+with_nettle
 with_secure_path
 with_facility
 '
@@ -1456,6 +1457,7 @@ Optional Packages:
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
   --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
                           compiler's sysroot if not specified).
+  --with-nettle           use nettle for crypto [default=no]
   --with-secure-path      PATH setting for exec'ed programs
   --with-facility         Syslog facility to use
 
@@ -14558,6 +14560,16 @@ $as_echo "no" >&6; }
 fi
 
 
+# Check whether --with-nettle was given.
+if test "${with_nettle+set}" = set; then :
+  withval=$with_nettle; with_nettle=$withval
+else
+  with_nettle=no
+fi
+
+
+if test "$with_nettle" != no; then
+
 
 
 
@@ -14736,31 +14748,11 @@ fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$NETTLE_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (nettle >= 2.4) were not met:
-
-$NETTLE_PKG_ERRORS
-
-Consider adjusting the PKG_CONFIG_PATH environment variable if you
-installed software in a non-standard prefix.
-
-Alternatively, you may set the environment variables NETTLE_CFLAGS
-and NETTLE_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details." "$LINENO" 5
+	use_nettle=no
 elif test $pkg_failed = untried; then
      	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
-is in your PATH or set the PKG_CONFIG environment variable to the full
-path to pkg-config.
-
-Alternatively, you may set the environment variables NETTLE_CFLAGS
-and NETTLE_LIBS to avoid the need to call pkg-config.
-See the pkg-config man page for more details.
-
-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
-See \`config.log' for more details" "$LINENO" 5; }
+	use_nettle=no
 else
 	NETTLE_CFLAGS=$pkg_cv_NETTLE_CFLAGS
 	NETTLE_LIBS=$pkg_cv_NETTLE_LIBS
@@ -14769,12 +14761,13 @@ $as_echo "yes" >&6; }
 	use_nettle=yes
 fi
 
-if test "$use_nettle" = yes;then
-	CRYPTO_CFLAGS="$NETTLE_CFLAGS"
-	CRYPTO_LIBS="$NETTLE_LIBS"
+	if test "$use_nettle" = yes;then
+		CRYPTO_CFLAGS="$NETTLE_CFLAGS"
+		CRYPTO_LIBS="$NETTLE_LIBS"
 
 $as_echo "#define HAVE_NETTLE 1" >>confdefs.h
 
+	fi
 fi
 
  if test "$use_nettle" = "yes"; then

--- a/configure.in
+++ b/configure.in
@@ -1,11 +1,11 @@
-#
+# 
 #  $Id: configure.in,v 1.38 2008/03/05 18:02:55 cparker Exp $
-#
+# 
 #  Copyright (C) 1996,1997 Lars Fenneberg
-#
-#  See the file COPYRIGHT for the respective terms and conditions.
-#
-#
+# 
+#  See the file COPYRIGHT for the respective terms and conditions. 
+# 
+# 
 
 AC_INIT
 
@@ -137,7 +137,7 @@ if test "x$gethostbynamerstyle" = "x"; then
 #include <stdio.h>
 #include <netdb.h>
 ], [ gethostbyname_r(NULL, NULL, NULL, 0, NULL) ] , [
-        AC_DEFINE(GETHOSTBYNAME_R)
+        AC_DEFINE(GETHOSTBYNAME_R)        
 	AC_DEFINE([GETHOSTBYNAMERSTYLE_SYSV], [], [Define to 1 to use sysv-style gethostbyname_r()])
         gethostbynamerstyle=SYSV
 ])
@@ -211,7 +211,7 @@ then
 	AC_MSG_CHECKING([for field domainname in struct utsname])
 	AC_TRY_RUN([
 	#include <sys/utsname.h>
-
+	
 	main(int argc, char **argv)
 	{
 		struct utsname uts;
@@ -243,12 +243,19 @@ else
 	AC_MSG_RESULT(no)
 fi
 
-PKG_CHECK_MODULES(NETTLE, [nettle >= 2.4], [use_nettle=yes])
+AC_ARG_WITH([nettle], [AS_HELP_STRING([--with-nettle],
+	[use nettle for crypto @<:@default=no@:>@])],
+	[with_nettle=$withval],
+	[with_nettle=no])
 
-if test "$use_nettle" = yes;then
-	CRYPTO_CFLAGS="$NETTLE_CFLAGS"
-	CRYPTO_LIBS="$NETTLE_LIBS"
-	AC_DEFINE([HAVE_NETTLE], 1, [Define to 1 to use nettle for MD5.])
+if test "$with_nettle" != no; then
+	PKG_CHECK_MODULES(NETTLE, [nettle >= 2.4], [use_nettle=yes], [use_nettle=no])
+
+	if test "$use_nettle" = yes;then
+		CRYPTO_CFLAGS="$NETTLE_CFLAGS"
+		CRYPTO_LIBS="$NETTLE_LIBS"
+		AC_DEFINE([HAVE_NETTLE], 1, [Define to 1 to use nettle for MD5.])
+	fi
 fi
 
 AM_CONDITIONAL(ENABLE_NETTLE, test "$use_nettle" = "yes")

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -3,8 +3,8 @@
 #
 # Copyright (C) 1995,1997,1998 Lars Fenneberg
 #
-# See the file COPYRIGHT for the respective terms and conditions. 
-# If the file is missing contact me at lf@elemental.net 
+# See the file COPYRIGHT for the respective terms and conditions.
+# If the file is missing contact me at lf@elemental.net
 # and I'll send you a copy.
 #
 
@@ -21,10 +21,12 @@ CLEANFILES = *~
 lib_LTLIBRARIES =   libfreeradius-client.la
 libfreeradius_client_la_SOURCES = buildreq.c clientid.c env.c sendserver.c \
 	avpair.c config.c dict.c ip_util.c log.c util.c  \
-	options.h rc-md5.h rc-md5.c util.h
+	options.h rc-md5.h rc-md5.c util.h rc-hmac.h
 
 if !ENABLE_NETTLE
-libfreeradius_client_la_SOURCES += md5.c md5.h
+libfreeradius_client_la_SOURCES += md5.c md5.h hmac.c hmac.h
+else
+libfreeradius_client_la_SOURCES += nettle-hmac.c
 endif
 
 libfreeradius_client_la_LDFLAGS = -version-info $(LIBVERSION)

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -19,8 +19,8 @@
 #
 # Copyright (C) 1995,1997,1998 Lars Fenneberg
 #
-# See the file COPYRIGHT for the respective terms and conditions. 
-# If the file is missing contact me at lf@elemental.net 
+# See the file COPYRIGHT for the respective terms and conditions.
+# If the file is missing contact me at lf@elemental.net
 # and I'll send you a copy.
 #
 
@@ -99,7 +99,8 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 target_triplet = @target@
-@ENABLE_NETTLE_FALSE@am__append_1 = md5.c md5.h
+@ENABLE_NETTLE_FALSE@am__append_1 = md5.c md5.h hmac.c hmac.h
+@ENABLE_NETTLE_TRUE@am__append_2 = nettle-hmac.c
 subdir = lib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/configure.in
@@ -143,11 +144,13 @@ am__DEPENDENCIES_1 =
 libfreeradius_client_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
 am__libfreeradius_client_la_SOURCES_DIST = buildreq.c clientid.c env.c \
 	sendserver.c avpair.c config.c dict.c ip_util.c log.c util.c \
-	options.h rc-md5.h rc-md5.c util.h md5.c md5.h
-@ENABLE_NETTLE_FALSE@am__objects_1 = md5.lo
+	options.h rc-md5.h rc-md5.c util.h rc-hmac.h md5.c md5.h \
+	hmac.c hmac.h nettle-hmac.c
+@ENABLE_NETTLE_FALSE@am__objects_1 = md5.lo hmac.lo
+@ENABLE_NETTLE_TRUE@am__objects_2 = nettle-hmac.lo
 am_libfreeradius_client_la_OBJECTS = buildreq.lo clientid.lo env.lo \
 	sendserver.lo avpair.lo config.lo dict.lo ip_util.lo log.lo \
-	util.lo rc-md5.lo $(am__objects_1)
+	util.lo rc-md5.lo $(am__objects_1) $(am__objects_2)
 libfreeradius_client_la_OBJECTS =  \
 	$(am_libfreeradius_client_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -360,7 +363,8 @@ CLEANFILES = *~
 lib_LTLIBRARIES = libfreeradius-client.la
 libfreeradius_client_la_SOURCES = buildreq.c clientid.c env.c \
 	sendserver.c avpair.c config.c dict.c ip_util.c log.c util.c \
-	options.h rc-md5.h rc-md5.c util.h $(am__append_1)
+	options.h rc-md5.h rc-md5.c util.h rc-hmac.h $(am__append_1) \
+	$(am__append_2)
 libfreeradius_client_la_LDFLAGS = -version-info $(LIBVERSION)
 libfreeradius_client_la_LIBADD = $(CRYPTO_LIBS)
 all: all-am
@@ -447,9 +451,11 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/config.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/dict.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/env.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/hmac.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ip_util.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/log.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/md5.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nettle-hmac.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/rc-md5.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/sendserver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util.Plo@am__quote@

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -1,0 +1,157 @@
+/*
+ * FILE:    hmac.c
+ * AUTHORS: Colin Perkins
+ *
+ * HMAC message authentication (RFC2104)
+ *
+ * Copyright (c) 1998-2000 University College London
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, is permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the Computer Science
+ *      Department at University College London
+ * 4. Neither the name of the University nor of the Department may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "md5.h"
+#include "hmac.h"
+
+/**
+ * hmac_md5:
+ * @data: pointer to data stream.
+ * @data_len: length of data stream in bytes.
+ * @key: pointer to authentication key.
+ * @key_len: length of authentication key in bytes.
+ * @digest: digest to be filled in.
+ *
+ * Computes MD5 @digest of @data using key @key.
+ *
+ **/
+void hmac_md5(unsigned char   *data,
+	      int              data_len,
+	      unsigned char   *key,
+	      int              key_len,
+	      unsigned char    digest[16])
+{
+        MD5_CTX       context;
+        unsigned char k_ipad[65];    /* inner padding - key XORd with ipad */
+        unsigned char k_opad[65];    /* outer padding - key XORd with opad */
+        unsigned char tk[16];
+        int           i;
+
+        /* If key is longer than 64 bytes reset it to key=MD5(key) */
+        if (key_len > 64) {
+                MD5_CTX      tctx;
+
+                MD5Init(&tctx);
+                MD5Update(&tctx, key, key_len);
+                MD5Final(tk, &tctx);
+
+                key     = tk;
+                key_len = 16;
+        }
+
+        /*
+         * The HMAC_MD5 transform looks like:
+         *
+         * MD5(K XOR opad, MD5(K XOR ipad, data))
+         *
+         * where K is an n byte key
+         * ipad is the byte 0x36 repeated 64 times
+         * opad is the byte 0x5c repeated 64 times
+         * and text is the data being protected
+         */
+
+        /* Start out by storing key in pads */
+        memset(k_ipad, 0, sizeof(k_ipad));
+        memset(k_opad, 0, sizeof(k_opad));
+        memcpy(k_ipad, key, key_len);
+        memcpy(k_opad, key, key_len);
+
+        /* XOR key with ipad and opad values */
+        for (i=0; i<64; i++) {
+                k_ipad[i] ^= 0x36;
+                k_opad[i] ^= 0x5c;
+        }
+        /*
+         * perform inner MD5
+         */
+        MD5Init(&context);                   /* init context for 1st pass */
+        MD5Update(&context, k_ipad, 64);     /* start with inner pad      */
+        MD5Update(&context, data, data_len); /* then text of datagram     */
+        MD5Final(digest, &context);          /* finish up 1st pass        */
+        /*
+         * perform outer MD5
+         */
+        MD5Init(&context);                   /* init context for 2nd pass */
+        MD5Update(&context, k_opad, 64);     /* start with outer pad      */
+        MD5Update(&context, digest, 16);     /* then results of 1st hash  */
+        MD5Final(digest, &context);          /* finish up 2nd pass        */
+}
+
+/*
+ * Test Vectors (Trailing '\0' of a character string not included in test):
+ *
+ * key =         0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+ * key_len =     16 bytes
+ * data =        "Hi There"
+ * data_len =    8  bytes
+ * digest =      0x9294727a3638bb1c13f48ef8158bfc9d
+ *
+ * key =         "Jefe"
+ * data =        "what do ya want for nothing?"
+ * data_len =    28 bytes
+ * digest =      0x750c783e6ab0b503eaa86e310a5db738
+ *
+ * key =         0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+ * key_len       16 bytes
+ * data =        0xDDDDDDDDDDDDDDDDDDDD...
+ *               ..DDDDDDDDDDDDDDDDDDDD...
+ *               ..DDDDDDDDDDDDDDDDDDDD...
+ *               ..DDDDDDDDDDDDDDDDDDDD...
+ *               ..DDDDDDDDDDDDDDDDDDDD
+ * data_len =    50 bytes
+ * digest =      0x56be34521d144c88dbb8c733f0e8b3f6
+ */
+
+#ifdef TEST_HMAC
+int main()
+{
+	unsigned char	*key  = "Jefe";
+	unsigned char	*data = "what do ya want for nothing?";
+	unsigned char	 digest[16];
+	int		 i;
+
+	hmac_md5(data, 28, key, 4, digest);
+	for (i = 0; i < 16; i++) {
+		printf("%02x", digest[i]);
+	}
+	printf("\n");
+
+	return 0;
+}
+#endif
+
+

--- a/lib/hmac.h
+++ b/lib/hmac.h
@@ -1,0 +1,44 @@
+#ifndef _HMAC_H
+#define _HMAC_H
+/*
+ * FILE:    hmac.h
+ * AUTHORS: Colin Perkins
+ *
+ * HMAC message authentication (RFC2104)
+ *
+ * Copyright (c) 1998-2000 University College London
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, is permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *      This product includes software developed by the Computer Science
+ *      Department at University College London
+ * 4. Neither the name of the University nor of the Department may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+void hmac_md5(unsigned char *data, int data_len,
+              unsigned char *key,  int key_len,
+	      unsigned char  digest[16]);
+
+#endif /* _HMAC_H */

--- a/lib/nettle-hmac.c
+++ b/lib/nettle-hmac.c
@@ -1,0 +1,46 @@
+/**
+* License: 2-clause BSD
+*
+* Copyright (c) 2016, Martin Belanger <nitram_67@hotmail.com>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those
+* of the authors and should not be interpreted as representing official policies,
+* either expressed or implied, of the FreeBSD Project.
+*/
+
+#include <nettle/hmac.h>
+#include <string.h>         /* memset() */
+#include "rc-hmac.h"
+
+void nettle_hmac_md5(unsigned char *data, int  data_len,
+                     unsigned char *key,  int  key_len,
+                     unsigned char  digest[MD5_DIGEST_SIZE])
+{
+    struct hmac_md5_ctx md5;
+    memset(digest, 0, MD5_DIGEST_SIZE);
+    hmac_md5_set_key(&md5, key_len, key);
+    hmac_md5_update(&md5, data_len, data);
+    hmac_md5_digest(&md5, MD5_DIGEST_SIZE, digest);
+}
+

--- a/lib/rc-hmac.h
+++ b/lib/rc-hmac.h
@@ -1,0 +1,53 @@
+#ifndef _RC_HMAC_H
+#define _RC_HMAC_H
+/**
+* License: 2-clause BSD
+*
+* Copyright (c) 2016, Martin Belanger <nitram_67@hotmail.com>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those
+* of the authors and should not be interpreted as representing official policies,
+* either expressed or implied, of the FreeBSD Project.
+*/
+
+#include "config.h" /* HAVE_NETTLE */
+
+#ifdef HAVE_NETTLE
+
+#include <nettle/hmac.h>
+extern void nettle_hmac_md5(unsigned char *data, int  data_len,
+                            unsigned char *key,  int  key_len,
+                            unsigned char  digest[MD5_DIGEST_SIZE]);
+#define rc_hmac_md5      nettle_hmac_md5
+
+#else  /* HAVE_NETTLE */
+
+#include "hmac.h"
+
+#define MD5_DIGEST_SIZE  16
+#define rc_hmac_md5      hmac_md5
+
+#endif /* HAVE_NETTLE */
+
+#endif /* _RC_HMAC_H */

--- a/lib/sendserver.c
+++ b/lib/sendserver.c
@@ -21,7 +21,7 @@
 #include <freeradius-client.h>
 #include <pathnames.h>
 #include "util.h"
-#include <nettle/hmac.h>
+#include "rc-hmac.h"
 
 #define	SA(p)	((struct sockaddr *)(p))
 
@@ -205,12 +205,8 @@ static int add_msg_auth_attr(rc_handle * rh, char * secret,
 	auth->length = htons((unsigned short)total_length);
 
 	/* Calulate HMAC-MD5 [RFC2104] hash */
-	struct hmac_md5_ctx md5;
 	uint8_t digest[MD5_DIGEST_SIZE];
-	memset(digest, 0, MD5_DIGEST_SIZE);
-	hmac_md5_set_key(&md5, secretlen, (unsigned char *)secret);
-	hmac_md5_update(&md5, total_length, (unsigned char *)auth);
-	hmac_md5_digest(&md5, MD5_DIGEST_SIZE, digest);
+	rc_hmac_md5((unsigned char *)auth, total_length, (unsigned char *)secret, secretlen, digest);
 	memcpy(&msg_auth[2], digest, MD5_DIGEST_SIZE);
 
 	return total_length;


### PR DESCRIPTION
I reverted the changes that made nettle mandatory.
Found a way to use MD5 algorithm to generate HMAC.